### PR TITLE
feat: implement simulation manifest generator

### DIFF
--- a/arc_memory/simulate/causal.py
+++ b/arc_memory/simulate/causal.py
@@ -173,6 +173,12 @@ def derive_causal(db_path: str) -> CausalGraph:
     logger.info(f"Deriving causal graph from {db_path}")
 
     try:
+        # Check if the database file exists
+        db_file = Path(db_path)
+        if not db_file.exists():
+            logger.warning(f"Database file not found: {db_path}")
+            return CausalGraph(nx.DiGraph())
+
         # Connect to the database
         conn = get_connection(db_path)
 

--- a/arc_memory/simulate/causal.py
+++ b/arc_memory/simulate/causal.py
@@ -231,6 +231,7 @@ def map_files_to_services(conn: sqlite3.Connection, causal_graph: CausalGraph) -
         if not file_nodes:
             cursor = conn.execute("SELECT id, title FROM nodes WHERE type = 'file'")
             file_nodes = {row[0]: row[1] for row in cursor.fetchall()}
+            logger.debug(f"Fallback to title field used. Found {len(file_nodes)} file nodes.")
 
         # Get all commit nodes
         cursor = conn.execute("SELECT id FROM nodes WHERE type = 'commit'")

--- a/arc_memory/simulate/causal.py
+++ b/arc_memory/simulate/causal.py
@@ -213,9 +213,24 @@ def map_files_to_services(conn: sqlite3.Connection, causal_graph: CausalGraph) -
         causal_graph: The causal graph to update
     """
     try:
-        # Get all file nodes
-        cursor = conn.execute("SELECT id, path FROM nodes WHERE type = 'file'")
-        file_nodes = {row[0]: row[1] for row in cursor.fetchall()}
+        # Get all file nodes - the path is stored in the extra JSON field
+        cursor = conn.execute("SELECT id, extra FROM nodes WHERE type = 'file'")
+        file_nodes = {}
+        for row in cursor.fetchall():
+            node_id = row[0]
+            extra_json = row[1]
+            if extra_json:
+                try:
+                    extra = json.loads(extra_json)
+                    if 'path' in extra:
+                        file_nodes[node_id] = extra['path']
+                except json.JSONDecodeError:
+                    logger.warning(f"Failed to parse extra JSON for node {node_id}")
+
+        # If we didn't find any paths in the extra field, try the title field
+        if not file_nodes:
+            cursor = conn.execute("SELECT id, title FROM nodes WHERE type = 'file'")
+            file_nodes = {row[0]: row[1] for row in cursor.fetchall()}
 
         # Get all commit nodes
         cursor = conn.execute("SELECT id FROM nodes WHERE type = 'commit'")

--- a/arc_memory/simulate/manifest.py
+++ b/arc_memory/simulate/manifest.py
@@ -134,7 +134,8 @@ class ManifestGenerator:
             "kind": "Schedule",
             "metadata": {
                 "name": "empty-schedule",
-                "namespace": "default"
+                "namespace": "default",
+                "annotations": {}
             },
             "spec": {
                 "schedule": "0 * * * *",
@@ -436,9 +437,15 @@ def generate_simulation_manifest(
     # Calculate the manifest hash
     manifest_hash = generator.calculate_manifest_hash(manifest)
 
+    # Ensure the metadata field exists
+    if "metadata" not in manifest:
+        manifest["metadata"] = {}
+
+    # Ensure the annotations field exists
+    if "annotations" not in manifest["metadata"]:
+        manifest["metadata"]["annotations"] = {}
+
     # Add the hash to the manifest
-    manifest["metadata"]["annotations"] = {
-        "arc-memory.io/manifest-hash": manifest_hash
-    }
+    manifest["metadata"]["annotations"]["arc-memory.io/manifest-hash"] = manifest_hash
 
     return manifest

--- a/arc_memory/simulate/manifest.py
+++ b/arc_memory/simulate/manifest.py
@@ -1,0 +1,444 @@
+"""Simulation manifest generation for Arc Memory.
+
+This module provides functions for generating simulation manifests for Chaos Mesh
+experiments based on the affected services identified by the causal graph.
+"""
+
+import hashlib
+import json
+import os
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Any, Union
+
+import yaml
+
+from arc_memory.logging_conf import get_logger
+from arc_memory.simulate.causal import CausalGraph, get_affected_services
+
+logger = get_logger(__name__)
+
+
+class FaultScenario(str, Enum):
+    """Types of fault scenarios supported by the simulation."""
+
+    NETWORK_LATENCY = "network_latency"
+    CPU_STRESS = "cpu_stress"
+    MEMORY_PRESSURE = "memory_pressure"
+    DISK_IO = "disk_io"
+
+
+class ManifestGenerator:
+    """Generator for Chaos Mesh experiment manifests."""
+
+    def __init__(
+        self,
+        causal_graph: CausalGraph,
+        scenario: str = FaultScenario.NETWORK_LATENCY,
+        severity: int = 50,
+    ):
+        """Initialize the manifest generator.
+
+        Args:
+            causal_graph: The causal graph derived from the TKG
+            scenario: The fault scenario to simulate
+            severity: The severity level (0-100) of the fault
+        """
+        self.causal_graph = causal_graph
+        self.scenario = self._validate_scenario(scenario)
+        self.severity = self._validate_severity(severity)
+
+    def _validate_scenario(self, scenario: str) -> str:
+        """Validate and normalize the scenario name.
+
+        Args:
+            scenario: The scenario name to validate
+
+        Returns:
+            The normalized scenario name
+
+        Raises:
+            ValueError: If the scenario is not supported
+        """
+        try:
+            return FaultScenario(scenario.lower())
+        except ValueError:
+            valid_scenarios = ", ".join([s.value for s in FaultScenario])
+            raise ValueError(
+                f"Unsupported scenario: {scenario}. "
+                f"Valid scenarios are: {valid_scenarios}"
+            )
+
+    def _validate_severity(self, severity: int) -> int:
+        """Validate the severity level.
+
+        Args:
+            severity: The severity level to validate
+
+        Returns:
+            The validated severity level
+
+        Raises:
+            ValueError: If the severity is not in the range 0-100
+        """
+        if not 0 <= severity <= 100:
+            raise ValueError(
+                f"Severity must be in the range 0-100, got {severity}"
+            )
+        return severity
+
+    def generate_manifest(
+        self, affected_files: List[str], target_services: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Generate a simulation manifest for the affected services.
+
+        Args:
+            affected_files: List of files affected by the changes
+            target_services: Optional list of target services to simulate
+                If not provided, will be derived from affected_files
+
+        Returns:
+            A dictionary containing the simulation manifest
+        """
+        # Identify affected services if not provided
+        if target_services is None:
+            target_services = get_affected_services(self.causal_graph, affected_files)
+
+        if not target_services:
+            logger.warning("No target services identified for simulation")
+            return self._generate_empty_manifest()
+
+        # Generate the appropriate manifest based on the scenario
+        if self.scenario == FaultScenario.NETWORK_LATENCY:
+            return self._generate_network_latency_manifest(target_services)
+        elif self.scenario == FaultScenario.CPU_STRESS:
+            return self._generate_cpu_stress_manifest(target_services)
+        elif self.scenario == FaultScenario.MEMORY_PRESSURE:
+            return self._generate_memory_pressure_manifest(target_services)
+        elif self.scenario == FaultScenario.DISK_IO:
+            return self._generate_disk_io_manifest(target_services)
+        else:
+            # This should never happen due to validation in __init__
+            logger.error(f"Unsupported scenario: {self.scenario}")
+            return self._generate_empty_manifest()
+
+    def _generate_empty_manifest(self) -> Dict[str, Any]:
+        """Generate an empty manifest when no services are affected.
+
+        Returns:
+            An empty manifest dictionary
+        """
+        return {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "Schedule",
+            "metadata": {
+                "name": "empty-schedule",
+                "namespace": "default"
+            },
+            "spec": {
+                "schedule": "0 * * * *",
+                "historyLimit": 1,
+                "concurrencyPolicy": "Forbid",
+                "type": "NetworkChaos",
+                "networkChaos": {
+                    "action": "delay",
+                    "mode": "one",
+                    "selector": {
+                        "namespaces": ["default"],
+                        "labelSelectors": {"app": "nonexistent"}
+                    },
+                    "delay": {
+                        "latency": "0ms",
+                        "correlation": "0",
+                        "jitter": "0ms"
+                    }
+                }
+            }
+        }
+
+    def _generate_network_latency_manifest(self, target_services: List[str]) -> Dict[str, Any]:
+        """Generate a network latency manifest for the target services.
+
+        Args:
+            target_services: List of services to target
+
+        Returns:
+            A dictionary containing the network latency manifest
+        """
+        # Calculate latency based on severity
+        # Severity 0 = 0ms, Severity 100 = 1000ms
+        latency_ms = int(self.severity * 10)
+
+        # Calculate jitter based on severity (10% of latency)
+        jitter_ms = int(latency_ms * 0.1)
+
+        # Calculate correlation based on severity
+        # Higher severity = higher correlation (more consistent latency)
+        correlation = self.severity / 100
+
+        # Generate a unique name for the experiment
+        experiment_name = f"network-latency-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+        # Create the manifest
+        manifest = {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "NetworkChaos",
+            "metadata": {
+                "name": experiment_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "action": "delay",
+                "mode": "all",
+                "selector": {
+                    "namespaces": ["default"],
+                    "labelSelectors": {
+                        "service": "|".join(target_services)
+                    }
+                },
+                "delay": {
+                    "latency": f"{latency_ms}ms",
+                    "correlation": str(correlation),
+                    "jitter": f"{jitter_ms}ms"
+                },
+                "duration": "5m"
+            }
+        }
+
+        return manifest
+
+    def _generate_cpu_stress_manifest(self, target_services: List[str]) -> Dict[str, Any]:
+        """Generate a CPU stress manifest for the target services.
+
+        Args:
+            target_services: List of services to target
+
+        Returns:
+            A dictionary containing the CPU stress manifest
+        """
+        # Calculate CPU load based on severity
+        # Severity 0 = 0% CPU, Severity 100 = 100% CPU
+        cpu_load = self.severity
+
+        # Generate a unique name for the experiment
+        experiment_name = f"cpu-stress-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+        # Create the manifest
+        manifest = {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "StressChaos",
+            "metadata": {
+                "name": experiment_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "mode": "all",
+                "selector": {
+                    "namespaces": ["default"],
+                    "labelSelectors": {
+                        "service": "|".join(target_services)
+                    }
+                },
+                "stressors": {
+                    "cpu": {
+                        "workers": 1,
+                        "load": cpu_load
+                    }
+                },
+                "duration": "5m"
+            }
+        }
+
+        return manifest
+
+    def _generate_memory_pressure_manifest(self, target_services: List[str]) -> Dict[str, Any]:
+        """Generate a memory pressure manifest for the target services.
+
+        Args:
+            target_services: List of services to target
+
+        Returns:
+            A dictionary containing the memory pressure manifest
+        """
+        # Calculate memory consumption based on severity
+        # Severity 0 = 0MB, Severity 100 = 1024MB (1GB)
+        memory_mb = int(self.severity * 10.24)
+
+        # Generate a unique name for the experiment
+        experiment_name = f"memory-pressure-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+        # Create the manifest
+        manifest = {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "StressChaos",
+            "metadata": {
+                "name": experiment_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "mode": "all",
+                "selector": {
+                    "namespaces": ["default"],
+                    "labelSelectors": {
+                        "service": "|".join(target_services)
+                    }
+                },
+                "stressors": {
+                    "memory": {
+                        "workers": 1,
+                        "size": f"{memory_mb}MB"
+                    }
+                },
+                "duration": "5m"
+            }
+        }
+
+        return manifest
+
+    def _generate_disk_io_manifest(self, target_services: List[str]) -> Dict[str, Any]:
+        """Generate a disk I/O manifest for the target services.
+
+        Args:
+            target_services: List of services to target
+
+        Returns:
+            A dictionary containing the disk I/O manifest
+        """
+        # Calculate I/O workers based on severity
+        # Severity 0 = 1 worker, Severity 100 = 4 workers
+        workers = 1 + int(self.severity / 33)
+
+        # Generate a unique name for the experiment
+        experiment_name = f"disk-io-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
+        # Create the manifest
+        manifest = {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "IOChaos",
+            "metadata": {
+                "name": experiment_name,
+                "namespace": "default"
+            },
+            "spec": {
+                "action": "latency",
+                "mode": "all",
+                "selector": {
+                    "namespaces": ["default"],
+                    "labelSelectors": {
+                        "service": "|".join(target_services)
+                    }
+                },
+                "volumePath": "/data",
+                "path": "",
+                "delay": f"{self.severity}ms",
+                "percent": self.severity,
+                "duration": "5m"
+            }
+        }
+
+        return manifest
+
+    def save_manifest(self, manifest: Dict[str, Any], output_path: Union[str, Path]) -> None:
+        """Save the manifest to a YAML file.
+
+        Args:
+            manifest: The manifest to save
+            output_path: The path to save the manifest to
+        """
+        output_path = Path(output_path)
+
+        # Create parent directories if they don't exist
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save the manifest as YAML
+        with open(output_path, 'w') as f:
+            yaml.dump(manifest, f, default_flow_style=False)
+
+        logger.info(f"Saved manifest to {output_path}")
+
+    def calculate_manifest_hash(self, manifest: Dict[str, Any]) -> str:
+        """Calculate a hash of the manifest for attestation.
+
+        Args:
+            manifest: The manifest to hash
+
+        Returns:
+            A hash of the manifest
+        """
+        # Convert the manifest to a JSON string
+        manifest_json = json.dumps(manifest, sort_keys=True)
+
+        # Calculate the SHA-256 hash
+        hash_obj = hashlib.sha256(manifest_json.encode('utf-8'))
+
+        return hash_obj.hexdigest()
+
+
+def list_available_scenarios() -> List[Dict[str, str]]:
+    """List all available fault scenarios with descriptions.
+
+    Returns:
+        A list of dictionaries containing scenario IDs and descriptions
+    """
+    return [
+        {
+            "id": "network_latency",
+            "description": "Inject network latency between services"
+        },
+        {
+            "id": "cpu_stress",
+            "description": "Simulate CPU pressure on services"
+        },
+        {
+            "id": "memory_pressure",
+            "description": "Simulate memory pressure on services"
+        },
+        {
+            "id": "disk_io",
+            "description": "Simulate disk I/O pressure on services"
+        }
+    ]
+
+
+def generate_simulation_manifest(
+    causal_graph: CausalGraph,
+    affected_files: List[str],
+    scenario: str = FaultScenario.NETWORK_LATENCY,
+    severity: int = 50,
+    target_services: Optional[List[str]] = None,
+    output_path: Optional[Union[str, Path]] = None
+) -> Dict[str, Any]:
+    """Generate a simulation manifest for the affected services.
+
+    Args:
+        causal_graph: The causal graph derived from the TKG
+        affected_files: List of files affected by the changes
+        scenario: The fault scenario to simulate
+        severity: The severity level (0-100) of the fault
+        target_services: Optional list of target services to simulate
+            If not provided, will be derived from affected_files
+        output_path: Optional path to save the manifest to
+
+    Returns:
+        A dictionary containing the simulation manifest
+    """
+    # Create the manifest generator
+    generator = ManifestGenerator(causal_graph, scenario, severity)
+
+    # Generate the manifest
+    manifest = generator.generate_manifest(affected_files, target_services)
+
+    # Save the manifest if an output path is provided
+    if output_path:
+        generator.save_manifest(manifest, output_path)
+
+    # Calculate the manifest hash
+    manifest_hash = generator.calculate_manifest_hash(manifest)
+
+    # Add the hash to the manifest
+    manifest["metadata"]["annotations"] = {
+        "arc-memory.io/manifest-hash": manifest_hash
+    }
+
+    return manifest

--- a/tests/unit/simulate/test_causal.py
+++ b/tests/unit/simulate/test_causal.py
@@ -231,10 +231,11 @@ def test_get_affected_services():
     assert "db-service" in affected
 
 
+@mock.patch("arc_memory.simulate.causal.Path")
 @mock.patch("arc_memory.simulate.causal.build_networkx_graph")
 @mock.patch("arc_memory.simulate.causal.get_connection")
 @mock.patch("arc_memory.simulate.causal.map_files_to_services")
-def test_derive_causal(mock_map_files, mock_get_conn, mock_build_graph):
+def test_derive_causal(mock_map_files, mock_get_conn, mock_build_graph, mock_path):
     """Test deriving a causal graph from a database."""
     # Mock the database connection
     mock_conn = mock.MagicMock()
@@ -244,10 +245,17 @@ def test_derive_causal(mock_map_files, mock_get_conn, mock_build_graph):
     mock_graph = mock.MagicMock()
     mock_build_graph.return_value = mock_graph
 
+    # Mock the Path object
+    mock_path_instance = mock.MagicMock()
+    mock_path.return_value = mock_path_instance
+    mock_path_instance.exists.return_value = True
+
     # Call the function
     causal_graph = derive_causal("path/to/db")
 
     # Check that the mocks were called
+    mock_path.assert_called_once_with("path/to/db")
+    mock_path_instance.exists.assert_called_once()
     mock_get_conn.assert_called_once_with("path/to/db")
     mock_build_graph.assert_called_once_with(mock_conn)
     mock_map_files.assert_called_once()

--- a/tests/unit/simulate/test_manifest.py
+++ b/tests/unit/simulate/test_manifest.py
@@ -1,0 +1,319 @@
+"""Tests for the simulation manifest generator."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import networkx as nx
+import pytest
+import yaml
+
+from arc_memory.simulate.causal import CausalGraph
+from arc_memory.simulate.manifest import (
+    FaultScenario,
+    ManifestGenerator,
+    generate_simulation_manifest,
+    list_available_scenarios,
+)
+
+
+def test_fault_scenario_enum():
+    """Test the FaultScenario enum."""
+    assert FaultScenario.NETWORK_LATENCY == "network_latency"
+    assert FaultScenario.CPU_STRESS == "cpu_stress"
+    assert FaultScenario.MEMORY_PRESSURE == "memory_pressure"
+    assert FaultScenario.DISK_IO == "disk_io"
+
+
+def test_manifest_generator_init():
+    """Test initializing a manifest generator."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    
+    # Test with default parameters
+    generator = ManifestGenerator(causal_graph)
+    assert generator.causal_graph == causal_graph
+    assert generator.scenario == FaultScenario.NETWORK_LATENCY
+    assert generator.severity == 50
+    
+    # Test with custom parameters
+    generator = ManifestGenerator(
+        causal_graph, scenario=FaultScenario.CPU_STRESS, severity=75
+    )
+    assert generator.causal_graph == causal_graph
+    assert generator.scenario == FaultScenario.CPU_STRESS
+    assert generator.severity == 75
+
+
+def test_validate_scenario():
+    """Test validating a scenario."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph)
+    
+    # Test with valid scenarios
+    assert generator._validate_scenario("network_latency") == FaultScenario.NETWORK_LATENCY
+    assert generator._validate_scenario("NETWORK_LATENCY") == FaultScenario.NETWORK_LATENCY
+    assert generator._validate_scenario("cpu_stress") == FaultScenario.CPU_STRESS
+    
+    # Test with invalid scenario
+    with pytest.raises(ValueError):
+        generator._validate_scenario("invalid_scenario")
+
+
+def test_validate_severity():
+    """Test validating a severity level."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph)
+    
+    # Test with valid severity levels
+    assert generator._validate_severity(0) == 0
+    assert generator._validate_severity(50) == 50
+    assert generator._validate_severity(100) == 100
+    
+    # Test with invalid severity levels
+    with pytest.raises(ValueError):
+        generator._validate_severity(-1)
+    with pytest.raises(ValueError):
+        generator._validate_severity(101)
+
+
+def test_generate_network_latency_manifest():
+    """Test generating a network latency manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph, scenario=FaultScenario.NETWORK_LATENCY, severity=50)
+    
+    # Generate a manifest
+    manifest = generator._generate_network_latency_manifest(["api-service", "web-service"])
+    
+    # Check the manifest structure
+    assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
+    assert manifest["kind"] == "NetworkChaos"
+    assert "metadata" in manifest
+    assert "spec" in manifest
+    assert manifest["spec"]["action"] == "delay"
+    assert manifest["spec"]["selector"]["labelSelectors"]["service"] == "api-service|web-service"
+    assert "latency" in manifest["spec"]["delay"]
+    assert "correlation" in manifest["spec"]["delay"]
+    assert "jitter" in manifest["spec"]["delay"]
+
+
+def test_generate_cpu_stress_manifest():
+    """Test generating a CPU stress manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph, scenario=FaultScenario.CPU_STRESS, severity=50)
+    
+    # Generate a manifest
+    manifest = generator._generate_cpu_stress_manifest(["api-service", "web-service"])
+    
+    # Check the manifest structure
+    assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
+    assert manifest["kind"] == "StressChaos"
+    assert "metadata" in manifest
+    assert "spec" in manifest
+    assert manifest["spec"]["stressors"]["cpu"]["load"] == 50
+
+
+def test_generate_memory_pressure_manifest():
+    """Test generating a memory pressure manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph, scenario=FaultScenario.MEMORY_PRESSURE, severity=50)
+    
+    # Generate a manifest
+    manifest = generator._generate_memory_pressure_manifest(["api-service", "web-service"])
+    
+    # Check the manifest structure
+    assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
+    assert manifest["kind"] == "StressChaos"
+    assert "metadata" in manifest
+    assert "spec" in manifest
+    assert "memory" in manifest["spec"]["stressors"]
+    assert "size" in manifest["spec"]["stressors"]["memory"]
+
+
+def test_generate_disk_io_manifest():
+    """Test generating a disk I/O manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph, scenario=FaultScenario.DISK_IO, severity=50)
+    
+    # Generate a manifest
+    manifest = generator._generate_disk_io_manifest(["api-service", "web-service"])
+    
+    # Check the manifest structure
+    assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
+    assert manifest["kind"] == "IOChaos"
+    assert "metadata" in manifest
+    assert "spec" in manifest
+    assert manifest["spec"]["action"] == "latency"
+    assert manifest["spec"]["delay"] == "50ms"
+    assert manifest["spec"]["percent"] == 50
+
+
+def test_generate_empty_manifest():
+    """Test generating an empty manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph)
+    
+    # Generate an empty manifest
+    manifest = generator._generate_empty_manifest()
+    
+    # Check the manifest structure
+    assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
+    assert manifest["kind"] == "Schedule"
+    assert "metadata" in manifest
+    assert "spec" in manifest
+    assert manifest["spec"]["networkChaos"]["action"] == "delay"
+    assert manifest["spec"]["networkChaos"]["delay"]["latency"] == "0ms"
+
+
+def test_generate_manifest():
+    """Test generating a manifest."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    
+    # Map some files to services
+    causal_graph.map_file_to_service("src/api/main.py", "api-service")
+    causal_graph.map_file_to_service("src/web/index.js", "web-service")
+    
+    # Create a manifest generator
+    generator = ManifestGenerator(causal_graph)
+    
+    # Generate a manifest with affected files
+    manifest = generator.generate_manifest(["src/api/main.py"])
+    
+    # Check that the manifest targets the api-service
+    assert manifest["spec"]["selector"]["labelSelectors"]["service"] == "api-service"
+    
+    # Generate a manifest with target services
+    manifest = generator.generate_manifest([], target_services=["web-service"])
+    
+    # Check that the manifest targets the web-service
+    assert manifest["spec"]["selector"]["labelSelectors"]["service"] == "web-service"
+    
+    # Generate a manifest with no affected files or target services
+    manifest = generator.generate_manifest([])
+    
+    # Check that an empty manifest is generated
+    assert manifest["kind"] == "Schedule"
+    assert manifest["spec"]["networkChaos"]["selector"]["labelSelectors"]["app"] == "nonexistent"
+
+
+def test_save_manifest():
+    """Test saving a manifest to a file."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph)
+    
+    # Generate a manifest
+    manifest = generator._generate_network_latency_manifest(["api-service"])
+    
+    # Save the manifest to a temporary file
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as temp_file:
+        temp_path = temp_file.name
+    
+    try:
+        generator.save_manifest(manifest, temp_path)
+        
+        # Check that the file exists
+        assert os.path.exists(temp_path)
+        
+        # Load the manifest from the file
+        with open(temp_path, "r") as f:
+            loaded_manifest = yaml.safe_load(f)
+        
+        # Check that the loaded manifest matches the original
+        assert loaded_manifest["apiVersion"] == manifest["apiVersion"]
+        assert loaded_manifest["kind"] == manifest["kind"]
+        assert loaded_manifest["spec"]["action"] == manifest["spec"]["action"]
+    
+    finally:
+        # Clean up
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+
+def test_calculate_manifest_hash():
+    """Test calculating a manifest hash."""
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    generator = ManifestGenerator(causal_graph)
+    
+    # Generate a manifest
+    manifest = generator._generate_network_latency_manifest(["api-service"])
+    
+    # Calculate the hash
+    hash1 = generator.calculate_manifest_hash(manifest)
+    
+    # Check that the hash is a non-empty string
+    assert isinstance(hash1, str)
+    assert len(hash1) > 0
+    
+    # Modify the manifest
+    manifest["spec"]["delay"]["latency"] = "100ms"
+    
+    # Calculate the hash again
+    hash2 = generator.calculate_manifest_hash(manifest)
+    
+    # Check that the hash is different
+    assert hash1 != hash2
+
+
+def test_list_available_scenarios():
+    """Test listing available scenarios."""
+    scenarios = list_available_scenarios()
+    
+    # Check that the list contains the expected scenarios
+    assert len(scenarios) == 4
+    
+    # Check that each scenario has an ID and description
+    for scenario in scenarios:
+        assert "id" in scenario
+        assert "description" in scenario
+
+
+@mock.patch("arc_memory.simulate.manifest.ManifestGenerator")
+def test_generate_simulation_manifest(mock_generator_class):
+    """Test the generate_simulation_manifest function."""
+    # Mock the manifest generator
+    mock_generator = mock.MagicMock()
+    mock_generator_class.return_value = mock_generator
+    
+    # Mock the generate_manifest method
+    mock_manifest = {"metadata": {"annotations": {"arc-memory.io/manifest-hash": "test-hash"}}}
+    mock_generator.generate_manifest.return_value = mock_manifest
+    
+    # Create a causal graph
+    graph = nx.DiGraph()
+    causal_graph = CausalGraph(graph)
+    
+    # Call the function
+    manifest = generate_simulation_manifest(
+        causal_graph=causal_graph,
+        affected_files=["src/api/main.py"],
+        scenario="network_latency",
+        severity=50,
+        target_services=["api-service"],
+        output_path="test.yaml"
+    )
+    
+    # Check that the manifest generator was created with the correct parameters
+    mock_generator_class.assert_called_once_with(causal_graph, "network_latency", 50)
+    
+    # Check that generate_manifest was called with the correct parameters
+    mock_generator.generate_manifest.assert_called_once_with(
+        ["src/api/main.py"], ["api-service"]
+    )
+    
+    # Check that save_manifest was called with the correct parameters
+    mock_generator.save_manifest.assert_called_once_with(mock_manifest, "test.yaml")
+    
+    # Check that the manifest was returned
+    assert manifest == mock_manifest

--- a/tests/unit/simulate/test_manifest.py
+++ b/tests/unit/simulate/test_manifest.py
@@ -31,13 +31,13 @@ def test_manifest_generator_init():
     """Test initializing a manifest generator."""
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
-    
+
     # Test with default parameters
     generator = ManifestGenerator(causal_graph)
     assert generator.causal_graph == causal_graph
     assert generator.scenario == FaultScenario.NETWORK_LATENCY
     assert generator.severity == 50
-    
+
     # Test with custom parameters
     generator = ManifestGenerator(
         causal_graph, scenario=FaultScenario.CPU_STRESS, severity=75
@@ -52,12 +52,12 @@ def test_validate_scenario():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph)
-    
+
     # Test with valid scenarios
     assert generator._validate_scenario("network_latency") == FaultScenario.NETWORK_LATENCY
     assert generator._validate_scenario("NETWORK_LATENCY") == FaultScenario.NETWORK_LATENCY
     assert generator._validate_scenario("cpu_stress") == FaultScenario.CPU_STRESS
-    
+
     # Test with invalid scenario
     with pytest.raises(ValueError):
         generator._validate_scenario("invalid_scenario")
@@ -68,12 +68,12 @@ def test_validate_severity():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph)
-    
+
     # Test with valid severity levels
     assert generator._validate_severity(0) == 0
     assert generator._validate_severity(50) == 50
     assert generator._validate_severity(100) == 100
-    
+
     # Test with invalid severity levels
     with pytest.raises(ValueError):
         generator._validate_severity(-1)
@@ -86,10 +86,10 @@ def test_generate_network_latency_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph, scenario=FaultScenario.NETWORK_LATENCY, severity=50)
-    
+
     # Generate a manifest
     manifest = generator._generate_network_latency_manifest(["api-service", "web-service"])
-    
+
     # Check the manifest structure
     assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
     assert manifest["kind"] == "NetworkChaos"
@@ -107,10 +107,10 @@ def test_generate_cpu_stress_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph, scenario=FaultScenario.CPU_STRESS, severity=50)
-    
+
     # Generate a manifest
     manifest = generator._generate_cpu_stress_manifest(["api-service", "web-service"])
-    
+
     # Check the manifest structure
     assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
     assert manifest["kind"] == "StressChaos"
@@ -124,10 +124,10 @@ def test_generate_memory_pressure_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph, scenario=FaultScenario.MEMORY_PRESSURE, severity=50)
-    
+
     # Generate a manifest
     manifest = generator._generate_memory_pressure_manifest(["api-service", "web-service"])
-    
+
     # Check the manifest structure
     assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
     assert manifest["kind"] == "StressChaos"
@@ -142,10 +142,10 @@ def test_generate_disk_io_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph, scenario=FaultScenario.DISK_IO, severity=50)
-    
+
     # Generate a manifest
     manifest = generator._generate_disk_io_manifest(["api-service", "web-service"])
-    
+
     # Check the manifest structure
     assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
     assert manifest["kind"] == "IOChaos"
@@ -161,14 +161,16 @@ def test_generate_empty_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph)
-    
+
     # Generate an empty manifest
     manifest = generator._generate_empty_manifest()
-    
+
     # Check the manifest structure
     assert manifest["apiVersion"] == "chaos-mesh.org/v1alpha1"
     assert manifest["kind"] == "Schedule"
     assert "metadata" in manifest
+    assert "annotations" in manifest["metadata"]
+    assert isinstance(manifest["metadata"]["annotations"], dict)
     assert "spec" in manifest
     assert manifest["spec"]["networkChaos"]["action"] == "delay"
     assert manifest["spec"]["networkChaos"]["delay"]["latency"] == "0ms"
@@ -178,29 +180,29 @@ def test_generate_manifest():
     """Test generating a manifest."""
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
-    
+
     # Map some files to services
     causal_graph.map_file_to_service("src/api/main.py", "api-service")
     causal_graph.map_file_to_service("src/web/index.js", "web-service")
-    
+
     # Create a manifest generator
     generator = ManifestGenerator(causal_graph)
-    
+
     # Generate a manifest with affected files
     manifest = generator.generate_manifest(["src/api/main.py"])
-    
+
     # Check that the manifest targets the api-service
     assert manifest["spec"]["selector"]["labelSelectors"]["service"] == "api-service"
-    
+
     # Generate a manifest with target services
     manifest = generator.generate_manifest([], target_services=["web-service"])
-    
+
     # Check that the manifest targets the web-service
     assert manifest["spec"]["selector"]["labelSelectors"]["service"] == "web-service"
-    
+
     # Generate a manifest with no affected files or target services
     manifest = generator.generate_manifest([])
-    
+
     # Check that an empty manifest is generated
     assert manifest["kind"] == "Schedule"
     assert manifest["spec"]["networkChaos"]["selector"]["labelSelectors"]["app"] == "nonexistent"
@@ -211,29 +213,29 @@ def test_save_manifest():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph)
-    
+
     # Generate a manifest
     manifest = generator._generate_network_latency_manifest(["api-service"])
-    
+
     # Save the manifest to a temporary file
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as temp_file:
         temp_path = temp_file.name
-    
+
     try:
         generator.save_manifest(manifest, temp_path)
-        
+
         # Check that the file exists
         assert os.path.exists(temp_path)
-        
+
         # Load the manifest from the file
         with open(temp_path, "r") as f:
             loaded_manifest = yaml.safe_load(f)
-        
+
         # Check that the loaded manifest matches the original
         assert loaded_manifest["apiVersion"] == manifest["apiVersion"]
         assert loaded_manifest["kind"] == manifest["kind"]
         assert loaded_manifest["spec"]["action"] == manifest["spec"]["action"]
-    
+
     finally:
         # Clean up
         if os.path.exists(temp_path):
@@ -245,23 +247,23 @@ def test_calculate_manifest_hash():
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
     generator = ManifestGenerator(causal_graph)
-    
+
     # Generate a manifest
     manifest = generator._generate_network_latency_manifest(["api-service"])
-    
+
     # Calculate the hash
     hash1 = generator.calculate_manifest_hash(manifest)
-    
+
     # Check that the hash is a non-empty string
     assert isinstance(hash1, str)
     assert len(hash1) > 0
-    
+
     # Modify the manifest
     manifest["spec"]["delay"]["latency"] = "100ms"
-    
+
     # Calculate the hash again
     hash2 = generator.calculate_manifest_hash(manifest)
-    
+
     # Check that the hash is different
     assert hash1 != hash2
 
@@ -269,10 +271,10 @@ def test_calculate_manifest_hash():
 def test_list_available_scenarios():
     """Test listing available scenarios."""
     scenarios = list_available_scenarios()
-    
+
     # Check that the list contains the expected scenarios
     assert len(scenarios) == 4
-    
+
     # Check that each scenario has an ID and description
     for scenario in scenarios:
         assert "id" in scenario
@@ -285,15 +287,15 @@ def test_generate_simulation_manifest(mock_generator_class):
     # Mock the manifest generator
     mock_generator = mock.MagicMock()
     mock_generator_class.return_value = mock_generator
-    
+
     # Mock the generate_manifest method
     mock_manifest = {"metadata": {"annotations": {"arc-memory.io/manifest-hash": "test-hash"}}}
     mock_generator.generate_manifest.return_value = mock_manifest
-    
+
     # Create a causal graph
     graph = nx.DiGraph()
     causal_graph = CausalGraph(graph)
-    
+
     # Call the function
     manifest = generate_simulation_manifest(
         causal_graph=causal_graph,
@@ -303,17 +305,17 @@ def test_generate_simulation_manifest(mock_generator_class):
         target_services=["api-service"],
         output_path="test.yaml"
     )
-    
+
     # Check that the manifest generator was created with the correct parameters
     mock_generator_class.assert_called_once_with(causal_graph, "network_latency", 50)
-    
+
     # Check that generate_manifest was called with the correct parameters
     mock_generator.generate_manifest.assert_called_once_with(
         ["src/api/main.py"], ["api-service"]
     )
-    
+
     # Check that save_manifest was called with the correct parameters
     mock_generator.save_manifest.assert_called_once_with(mock_manifest, "test.yaml")
-    
+
     # Check that the manifest was returned
     assert manifest == mock_manifest


### PR DESCRIPTION
## Description
This PR implements Step 4 of our implementation plan: Create Simulation Manifest Generator. It adds functionality to generate Chaos Mesh manifests for fault injection experiments based on the affected services identified by the causal graph.

## Changes
- Create `ManifestGenerator` class for generating Chaos Mesh manifests
- Implement support for network_latency, cpu_stress, memory_pressure, and disk_io scenarios
- Add manifest hash calculation for attestation
- Update CLI to use the manifest generator
- Add comprehensive unit tests for the manifest generator
- Fix file path retrieval in causal graph derivation to correctly access paths from the database

## Testing
All tests pass, including the new unit tests for the manifest generator and causal graph derivation.

## Related Issues
Part of the `arc sim` command implementation.