### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/arc_memory/ingest/github.py
+++ b/arc_memory/ingest/github.py
@@ -44,7 +44,9 @@ def get_repo_info(repo_path: Path) -> Tuple[str, str]:
         github_remote = None
         for remote in remotes:
             for url in remote.urls:
-                if "github.com" in url:
+                from urllib.parse import urlparse
+                parsed_url = urlparse(url)
+                if parsed_url.hostname and (parsed_url.hostname == "github.com" or parsed_url.hostname.endswith(".github.com")):
                     github_remote = url
                     break
             if github_remote:


### PR DESCRIPTION
Potential fix for [https://github.com/Arc-Computer/arc-memory/security/code-scanning/8](https://github.com/Arc-Computer/arc-memory/security/code-scanning/8)

To fix the issue, the code should parse the URL using `urllib.parse` and validate the hostname to ensure it matches `github.com` or its subdomains. This approach avoids the pitfalls of substring checks and ensures that the URL is correctly identified as a GitHub remote.

The specific changes involve:
1. Replacing the substring check `"github.com" in url` with a parsed URL check using `urllib.parse.urlparse`.
2. Validating that the hostname of the parsed URL is either `github.com` or ends with `.github.com`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
