### PR TITLE
Clarify agent write access in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ during the 2022 pricing change (see ADR-012).
 ### Shared Memory for Humans and Agents
 
 As teams deploy more AI agents, Arc Memory provides the shared context layer they need to work together effectively, reducing duplicate work and conflicting changes.
+Agents can not only read the graph but also create `Node` and `Edge` objects and
+persist them with `Arc.add_nodes_and_edges()`.
 
 ## Getting Started
 

--- a/docs/examples/agents/README.md
+++ b/docs/examples/agents/README.md
@@ -45,4 +45,8 @@ python agents/code_review_assistant.py --repo /path/to/repo --files file1.py fil
 
 These examples are designed to be starting points for building your own agents. Feel free to modify them to suit your needs or use them as inspiration for building entirely new agents.
 
+Agents can also **write** to the knowledge graph. Create `Node` and `Edge`
+instances using the models in `arc_memory.schema.models` and call
+`Arc.add_nodes_and_edges()` to persist them.
+
 For more information on building agents with Arc Memory, see the [SDK Documentation](../../sdk/README.md).

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -175,6 +175,34 @@ assistant = openai_adapter.create_assistant(
 )
 ```
 
+## Writing to the Graph
+
+Agents can also **persist new knowledge** into Arc Memory. Create `Node` and
+`Edge` instances from `arc_memory.schema.models` and pass them to
+`arc.add_nodes_and_edges()`:
+
+```python
+from arc_memory import Arc
+from arc_memory.schema.models import Node, Edge, NodeType, EdgeRel
+
+arc = Arc(repo_path="./")
+
+doc = Node(
+    id="document:agent-note",
+    type=NodeType.DOCUMENT,
+    title="Agent Observation",
+    body="This was learned by the agent."
+)
+
+link = Edge(src=doc.id, dst="commit:abc123", rel=EdgeRel.REFERENCES)
+
+arc.add_nodes_and_edges([doc], [link])
+```
+
+This uses the same transactional write path as Arc's build process. SQLite is
+the default backend, so coordinate concurrent writes or use Neo4j if you need
+higher write throughput.
+
 ## Core Concepts
 
 ### Knowledge Graph


### PR DESCRIPTION
## Summary
- document that agents can call `Arc.add_nodes_and_edges()`
- note agent write access in examples and docs overview